### PR TITLE
refactor: migrate HTTP layer from Nickel to Axum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,10 +97,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "backtrace"
@@ -115,16 +176,6 @@ dependencies = [
  "object",
  "rustc-demangle",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "base64"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
-dependencies = [
- "byteorder",
- "safemem",
 ]
 
 [[package]]
@@ -294,16 +345,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "env_logger"
-version = "0.10.2"
+name = "errno"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
- "humantime",
- "is-terminal",
- "log 0.4.28",
- "regex",
- "termcolor",
+ "libc",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -317,6 +365,15 @@ name = "find-msvc-tools"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures-channel"
@@ -379,7 +436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
- "version_check 0.9.5",
+ "version_check",
 ]
 
 [[package]]
@@ -401,22 +458,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "groupable"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hmac"
@@ -428,34 +473,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "humantime"
-version = "2.3.0"
+name = "httpdate"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.10.16"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
- "base64 0.9.3",
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
  "httparse",
- "language-tags",
- "log 0.3.9",
- "mime",
- "num_cpus",
- "time 0.1.45",
- "traitobject",
- "typeable",
- "unicase",
- "url",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -468,7 +562,7 @@ dependencies = [
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
- "log 0.4.28",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -483,17 +577,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
 name = "io-uring"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,17 +585,6 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -545,12 +617,6 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "language-tags"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 
 [[package]]
 name = "lazy_static"
@@ -587,24 +653,24 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-dependencies = [
- "log 0.4.28",
-]
-
-[[package]]
-name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
-name = "matches"
-version = "0.1.10"
+name = "matchers"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "md-5"
@@ -624,12 +690,9 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "mime"
-version = "0.2.6"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
-dependencies = [
- "log 0.3.9",
-]
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -652,40 +715,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "modifier"
-version = "0.1.0"
+name = "nu-ansi-term"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f5c9112cb662acd3b204077e0de5bc66305fa8df65c8019d5adb10e9ab6e58"
-
-[[package]]
-name = "mustache"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51956ef1c5d20a1384524d91e616fb44dfc7d8f249bf696d49c97dd3289ecab5"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "log 0.3.9",
- "serde",
-]
-
-[[package]]
-name = "nickel"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5061a832728db2dacb61cefe0ce303b58f85764ec680e71d9138229640a46d9"
-dependencies = [
- "groupable",
- "hyper",
- "lazy_static",
- "log 0.3.9",
- "modifier",
- "mustache",
- "plugin",
- "regex",
- "serde",
- "serde_json",
- "time 0.1.45",
- "typemap",
- "url",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -701,16 +736,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -759,12 +784,6 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
-
-[[package]]
-name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
@@ -806,30 +825,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "plugin"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a6a0dc3910bc8db877ffed8e457763b317cf880df4ae19109b9f77d277cf6e0"
-dependencies = [
- "typemap",
-]
-
-[[package]]
 name = "pmetrics"
 version = "1.0.2"
 dependencies = [
+ "axum",
  "chrono",
  "clap",
  "either",
- "env_logger",
  "itertools",
- "log 0.4.28",
- "nickel",
  "percent-encoding-rfc3986",
  "postgres",
  "serde",
  "serde_json",
- "time 0.3.43",
+ "time",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -841,7 +854,7 @@ dependencies = [
  "bytes",
  "fallible-iterator",
  "futures-util",
- "log 0.4.28",
+ "log",
  "tokio",
  "tokio-postgres",
 ]
@@ -852,7 +865,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76ff0abab4a9b844b93ef7b81f1efc0a366062aaef2cd702c76256b5dc075c54"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -956,18 +969,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,12 +1002,6 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "scopeguard"
@@ -1057,6 +1052,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,10 +1086,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "siphasher"
@@ -1146,23 +1183,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
+name = "sync_wrapper"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
-name = "time"
-version = "0.1.45"
+name = "thread_local"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1210,10 +1242,24 @@ dependencies = [
  "io-uring",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "slab",
  "socket2 0.6.0",
+ "tokio-macros",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1228,9 +1274,9 @@ dependencies = [
  "fallible-iterator",
  "futures-channel",
  "futures-util",
- "log 0.4.28",
+ "log",
  "parking_lot",
- "percent-encoding 2.3.2",
+ "percent-encoding",
  "phf",
  "pin-project-lite",
  "postgres-protocol",
@@ -1256,24 +1302,110 @@ dependencies = [
 ]
 
 [[package]]
-name = "traitobject"
-version = "0.1.1"
+name = "tower"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04a79e25382e2e852e8da874249358d382ebaf259d0d34e75d8db16a7efabbc7"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
-name = "typeable"
-version = "0.1.2"
+name = "tower-http"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
-name = "typemap"
+name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "unsafe-any",
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1281,15 +1413,6 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
-
-[[package]]
-name = "unicase"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
-dependencies = [
- "version_check 0.1.5",
-]
 
 [[package]]
 name = "unicode-bidi"
@@ -1319,48 +1442,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
-name = "unsafe-any"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"
-dependencies = [
- "traitobject",
-]
-
-[[package]]
-name = "url"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-dependencies = [
- "idna",
- "matches",
- "percent-encoding 1.0.1",
-]
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "version_check"
-version = "0.1.5"
+name = "valuable"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -1412,7 +1509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
 dependencies = [
  "bumpalo",
- "log 0.4.28",
+ "log",
  "proc-macro2",
  "quote",
  "syn",
@@ -1471,37 +1568,6 @@ dependencies = [
  "wasite",
  "web-sys",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.0",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,10 @@ debug = true
 clap = { version = "4", features = ["derive"] }
 either = "1"
 itertools = "0.11.0"
-nickel = "0.11"
+axum = "0.7"
+tokio = { version = "1", features = ["full"] }
+tower = "0.5"
+tower-http = { version = "0.5", features = ["trace"] }
 percent-encoding-rfc3986 = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 postgres = { version = "0.19.10", features = [

--- a/src/bin/pmetrics.rs
+++ b/src/bin/pmetrics.rs
@@ -1,22 +1,24 @@
 /**
 pmetrics entry point
  **/
-#[macro_use]
-extern crate nickel;
-
+use axum::{
+    extract::Extension,
+    http::StatusCode,
+    middleware::{self, Next},
+    response::Response,
+    routing::{get, post},
+    Json, Router,
+};
 use clap::{Parser, Subcommand};
 use std::fs::File;
 use std::io;
 use std::io::Read;
 use std::{thread, time};
+use tower_http::trace::TraceLayer;
 
 use chrono::prelude::{DateTime, Utc};
 
-use nickel::status::StatusCode;
-use nickel::{/* QueryString, */ HttpRouter, MiddlewareResult, Nickel, Request, Response};
-use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-// this is /not obvious/.
 use pmetrics::db;
 use serde_json::Value;
 
@@ -60,6 +62,9 @@ struct Event {
     insertion_time: DateTime<Utc>,
 }
 
+#[derive(Clone, Copy)]
+struct TenantId(i32);
+
 // TODO: Api should have an accept: application/json request type, along with appropriate error codes.
 // Said error codes will be:
 //
@@ -76,42 +81,6 @@ struct Event {
 
 // TODO: Write a Search api.
 
-fn generic_post<T, F>(req: &mut Request, insert_function: F) -> (nickel::status::StatusCode, String)
-where
-    T: DeserializeOwned,
-    F: Fn(&mut postgres::Client, &T) -> Result<u64, postgres::Error>,
-{
-    let mut buffer = String::new();
-
-    match req.origin.read_to_string(&mut buffer) {
-        Ok(_) => {} // no-op
-        Err(_) => {
-            tracing::info!("error=true module=web class=string_read");
-            return (StatusCode::BadRequest, "unable to read string".to_string());
-        }
-    }
-
-    let v: Result<T, serde_json::Error> = serde_json::from_str(&buffer);
-    match v {
-        Ok(deserialized) => {
-            let mut conn = db::connect_to_db();
-            match insert_function(&mut conn, &deserialized) {
-                Ok(_) => (StatusCode::Ok, "ok".to_string()),
-                Err(err) => {
-                    tracing::debug!("error=true module=web class=db_insert details={err}");
-                    tracing::info!("error=true module=web class=db_insert");
-                    (StatusCode::BadGateway, "server error".to_string())
-                }
-            }
-        }
-
-        Err(_) => {
-            tracing::info!("error=true module=web class=deserialize/parse");
-            (StatusCode::BadRequest, "bad parse and cast".to_string())
-        }
-    }
-}
-
 fn writemeasure(
     conn: &mut postgres::Client,
     tid: i32,
@@ -121,70 +90,52 @@ fn writemeasure(
                  &[&l.name, &tid, &l.measurement, &l.dict])
 }
 
-fn postmeasure(req: &mut Request) -> (nickel::status::StatusCode, String) {
-    match get_tid(req) {
-        Some(tid) => {
-            let f = |conn: &mut postgres::Client,
-                     l: &MeasureIngest|
-             -> Result<u64, postgres::Error> { writemeasure(conn, tid, l) };
-
-            generic_post(req, f)
-        }
-        None => {
-            tracing::info!(
-                "error=true module=web what='failed to get the x tenant id from the middleware'"
-            );
-            (StatusCode::BadRequest, "\"key failure\"".to_string())
-        }
-    }
+async fn post_measure(
+    Extension(TenantId(tid)): Extension<TenantId>,
+    Json(body): Json<MeasureIngest>,
+) -> Result<StatusCode, (StatusCode, &'static str)> {
+    tokio::task::spawn_blocking(move || {
+        let mut conn = db::connect_to_db();
+        writemeasure(&mut conn, tid, &body)
+    })
+    .await
+    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "join error"))?
+    .map(|_| StatusCode::OK)
+    .map_err(|e| {
+        tracing::error!(?e, "db insert measure");
+        (StatusCode::BAD_GATEWAY, "server error")
+    })
 }
 
-// TODO: dry up.
-fn getmeasure(req: &mut Request) -> (nickel::status::StatusCode, String) {
-    let mut conn = db::connect_to_db();
-    let tid = match get_tid(req) {
-        Some(tid) => tid,
-        None => {
-            return (
-                StatusCode::BadRequest,
-                "could not get tenant id".to_string(),
-            );
-        }
-    };
-
-    let query = "SELECT insertion_time, name, measurement, dict from monitoring.measure where tenant_id = $1 order by insertion_time desc limit 100";
-    match conn.query(query, &[&tid]) {
-        Ok(rows) => {
-            let mut vec: Vec<Measure> = Vec::new();
-            for row in &rows {
-                vec.push(Measure {
-                    insertion_time: row.get(0),
-                    d: MeasureIngest {
-                        name: row.get(1),
-                        measurement: row.get(2),
-                        dict: row.get(3),
-                    },
-                });
-            }
-            match serde_json::to_string(&vec) {
-                Ok(s) => (StatusCode::Ok, s),
-                Err(e) => {
-                    tracing::error!("error=true module=web error={e:?} class=json-render");
-                    (
-                        StatusCode::InternalServerError,
-                        "server error, can't render data".to_string(),
-                    )
-                }
-            }
-        }
-        Err(e) => {
-            tracing::error!("error=true module=db error={} query={}", e, &query);
-            (
-                StatusCode::InternalServerError,
-                "server error, can't get data".to_string(),
-            )
-        }
-    }
+async fn get_measure(
+    Extension(TenantId(tid)): Extension<TenantId>,
+) -> Result<Json<Vec<Measure>>, (StatusCode, &'static str)> {
+    tokio::task::spawn_blocking(move || -> Result<Vec<Measure>, postgres::Error> {
+        let mut conn = db::connect_to_db();
+        let rows = conn.query(
+            "SELECT insertion_time, name, measurement, dict from monitoring.measure \
+             where tenant_id = $1 order by insertion_time desc limit 100",
+            &[&tid],
+        )?;
+        Ok(rows
+            .iter()
+            .map(|row| Measure {
+                insertion_time: row.get(0),
+                d: MeasureIngest {
+                    name: row.get(1),
+                    measurement: row.get(2),
+                    dict: row.get(3),
+                },
+            })
+            .collect())
+    })
+    .await
+    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "join error"))?
+    .map(Json)
+    .map_err(|e| {
+        tracing::error!(?e, "db query measures");
+        (StatusCode::INTERNAL_SERVER_ERROR, "server error")
+    })
 }
 
 fn writeevent(
@@ -198,282 +149,115 @@ fn writeevent(
     )
 }
 
-fn postevent(req: &mut Request) -> (nickel::status::StatusCode, String) {
-    match get_tid(req) {
-        Some(tid) => {
-            let f = |conn: &mut postgres::Client,
-                     l: &EventIngest|
-             -> Result<u64, postgres::Error> { writeevent(conn, tid, l) };
-
-            generic_post(req, f)
-        }
-        None => {
-            tracing::info!(
-                "error=true module=web what='failed to get the x tenant id from the middleware'"
-            );
-            (StatusCode::BadRequest, "\"key failure\"".to_string())
-        }
-    }
+async fn post_event(
+    Extension(TenantId(tid)): Extension<TenantId>,
+    Json(body): Json<EventIngest>,
+) -> Result<StatusCode, (StatusCode, &'static str)> {
+    tokio::task::spawn_blocking(move || {
+        let mut conn = db::connect_to_db();
+        writeevent(&mut conn, tid, &body)
+    })
+    .await
+    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "join error"))?
+    .map(|_| StatusCode::OK)
+    .map_err(|e| {
+        tracing::error!(?e, "db insert event");
+        (StatusCode::BAD_GATEWAY, "server error")
+    })
 }
 
-fn getevent(req: &mut Request) -> (nickel::status::StatusCode, String) {
-    let mut conn = db::connect_to_db();
-    let tid = match get_tid(req) {
-        Some(tid) => tid,
-        None => {
-            return (
-                StatusCode::BadRequest,
-                "could not get tenant id".to_string(),
-            );
-        }
-    };
-
-    let query = "SELECT insertion_time, name, dict from monitoring.event where tenant_id = $1 order by insertion_time desc limit 100";
-    let result = match conn.query(query, &[&tid]) {
-        Ok(rows) => {
-            let mut vec: Vec<Event> = Vec::new();
-            for row in &rows {
-                vec.push(Event {
-                    insertion_time: row.get(0),
-                    d: EventIngest {
-                        name: row.get(1),
-                        dict: row.get(2),
-                    },
-                });
-            }
-
-            match serde_json::to_string(&vec) {
-                Ok(s) => (StatusCode::Ok, s),
-                Err(e) => {
-                    tracing::error!("error=true module=web error={e:?} class=json-render");
-                    (
-                        StatusCode::InternalServerError,
-                        "server error, can't render data".to_string(),
-                    )
-                }
-            }
-        }
-        Err(e) => {
-            tracing::error!("error=true module=db error={e:?} query={query}");
-            (
-                StatusCode::InternalServerError,
-                "server error, can't get data".to_string(),
-            )
-        }
-    };
-    result
+async fn get_event(
+    Extension(TenantId(tid)): Extension<TenantId>,
+) -> Result<Json<Vec<Event>>, (StatusCode, &'static str)> {
+    tokio::task::spawn_blocking(move || -> Result<Vec<Event>, postgres::Error> {
+        let mut conn = db::connect_to_db();
+        let rows = conn.query(
+            "SELECT insertion_time, name, dict from monitoring.event \
+             where tenant_id = $1 order by insertion_time desc limit 100",
+            &[&tid],
+        )?;
+        Ok(rows
+            .iter()
+            .map(|row| Event {
+                insertion_time: row.get(0),
+                d: EventIngest {
+                    name: row.get(1),
+                    dict: row.get(2),
+                },
+            })
+            .collect())
+    })
+    .await
+    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "join error"))?
+    .map(Json)
+    .map_err(|e| {
+        tracing::error!(?e, "db query events");
+        (StatusCode::INTERNAL_SERVER_ERROR, "server error")
+    })
 }
 
-// index /
-fn handler(_req: &mut Request) -> (nickel::status::StatusCode, String) {
-    (StatusCode::Ok, "welcome to nickel'd pmetrics".to_string())
+async fn root() -> &'static str {
+    "welcome to pmetrics"
 }
 
-// healthz - am I alive?
-// does not check database liveness though.
-fn healthz(_req: &mut Request) -> (nickel::status::StatusCode, String) {
+async fn healthz() -> &'static str {
     tracing::info!("healthz");
-    (StatusCode::Ok, "ok".to_string())
+    "ok"
 }
 
 //////////////////////////////
 // API KEY / tenant middleware.
 
-fn get_tid(req: &Request) -> Option<i32> {
-    match req.origin.headers.get_raw("X-TENANT-ID") {
-        Some(s) => {
-            let thread_string = s[0].to_vec();
-            let tid_string = match String::from_utf8(thread_string) {
-                Ok(s) => s,
-                Err(e) => {
-                    tracing::info!("error=true module=web what='failed to parse tenant id from utf8' error='{e:?}'");
-                    return None;
-                }
-            };
-            match tid_string.parse() {
-                Ok(tid) => Some(tid),
-                Err(e) => {
-                    tracing::info!("error=true module=web what='failed to parse tenant id from string' error='{e:?}'");
-                    None
-                }
-            }
-        }
-        None => {
-            tracing::info!(
-                "error=true module=web what='failed to get the x tenant id from the middleware'"
-            );
+fn lookup_tenant_by_key(k: &str) -> Option<i32> {
+    let mut conn = db::connect_to_db();
+    let query = "SELECT uid from monitoring.tenant where apikey = $1";
+    match conn.query(query, &[&k.to_string()]) {
+        Ok(rows) => rows.first().map(|row| row.get(0)),
+        Err(e) => {
+            tracing::error!("error=true module=db error={e:?} query={query}");
             None
         }
     }
 }
 
-struct ApiKeys;
+async fn check_api_keys(
+    mut req: axum::extract::Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    let key = req
+        .headers()
+        .get("X-PMETRICS-API-KEY")
+        .and_then(|v| v.to_str().ok())
+        .ok_or(StatusCode::FORBIDDEN)?
+        .to_string();
 
-impl ApiKeys {
-    fn check_keys(&self, k: &str) -> Option<i32> {
-        // reads monitoring.apikeys
-        let mut conn = db::connect_to_db();
-        let mut vec: Vec<i32> = Vec::new();
-        let query = "SELECT uid from monitoring.tenant where apikey = $1";
-        let result = conn.query(query, &[&k.to_string()]);
+    let tid = tokio::task::spawn_blocking(move || lookup_tenant_by_key(&key))
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::FORBIDDEN)?;
 
-        match result {
-            Ok(rows) => {
-                for row in &rows {
-                    vec.push(row.get(0));
-                }
-                if !vec.is_empty() {
-                    Some(vec[0])
-                } else {
-                    None
-                }
-            }
-            Err(e) => {
-                tracing::error!("error=true module=db error={e:?} query={query}");
-                None
-            }
-        }
-    }
+    req.extensions_mut().insert(TenantId(tid));
+    Ok(next.run(req).await)
 }
 
-#[allow(clippy::result_large_err)]
-fn check_api_keys<'mw>(_req: &mut Request, mut res: Response<'mw>) -> MiddlewareResult<'mw> {
-    let path = match _req.path_without_query() {
-        Some(p) => p,
-        None => {
-            res.set(StatusCode::BadRequest);
-            return res.send("\"bad path\"");
-        }
-    };
-    // Cutout for non-api routes.
-    if !path.contains("api") {
-        return res.next_middleware();
-    }
+async fn launch_server(server_options: &ServerOptions) {
+    tracing::info!("server initializing");
 
-    match _req.origin.headers.get_raw("X-PMETRICS-API-KEY") {
-        Some(s) => {
-            let gatekeeper = ApiKeys {};
-            let header = &s[0];
-            let key = match String::from_utf8(header.to_vec()) {
-                Ok(s) => s,
-                Err(e) => {
-                    tracing::info!("error=true module=web what='failed to parse api key from utf8' error='{e:?}'");
-                    res.set(StatusCode::BadRequest);
-                    return res.send("\"api key failure\"");
-                }
-            };
-            let apikeys = gatekeeper.check_keys(&key);
-            match apikeys {
-                Some(v) => {
-                    // Set it for other users lower down in the middleware stack.
-                    _req.origin
-                        .headers
-                        .set_raw("X-TENANT-ID", vec![v.to_string().into_bytes()]);
-                }
-                None => {
-                    res.set(StatusCode::Forbidden);
+    let api = Router::new()
+        .route("/event", post(post_event).get(get_event))
+        .route("/measure", post(post_measure).get(get_measure))
+        .layer(middleware::from_fn(check_api_keys));
 
-                    return res.send("\"api key failure\"");
-                }
-            }
-        }
-        None => {
-            res.set(StatusCode::Forbidden);
+    let app = Router::new()
+        .route("/", get(root))
+        .route("/healthz", get(healthz))
+        .nest("/api/v1", api)
+        .layer(TraceLayer::new_for_http());
 
-            return res.send("\"api key failure\"");
-        }
-    }
-
-    // Pass control to the next middleware
-    res.next_middleware()
-}
-
-#[allow(clippy::result_large_err)]
-fn log_request<'mw>(_req: &mut Request, res: Response<'mw>) -> MiddlewareResult<'mw> {
-    let path = _req.path_without_query().unwrap_or("<no path>");
-    match _req.origin.headers.get_raw("X-PMETRICS-API-KEY") {
-        Some(key) => {
-            let header = &key[0];
-            let key = match String::from_utf8(header.to_vec()) {
-                Ok(s) => s,
-                Err(e) => {
-                    tracing::info!("error=true module=web what='failed to parse api key from utf8' error='{e:?}'");
-                    // Don't fail the request, just log the error and move on.
-                    "<unparseable>".to_string()
-                }
-            };
-            tracing::info!(
-                "module=web method={} url={} apikey={}",
-                &_req.origin.method.to_string(),
-                path,
-                &key,
-            );
-        }
-        None => {
-            tracing::info!(
-                "module=web method={} url={}",
-                &_req.origin.method.to_string(),
-                path,
-            );
-        }
-    }
-    res.next_middleware()
-}
-
-fn launch_server(server_options: &ServerOptions) {
-    tracing::info!("message='server initializing'");
-    let mut server = Nickel::new();
-
-    server.get(
-        "/healthz",
-        middleware! { |req|
-                                              healthz(req)
-        },
-    );
-
-    server.utilize(check_api_keys);
-
-    server.get(
-        "/",
-        middleware! { |req|
-                                      handler(req)
-        },
-    );
-
-    server.utilize(log_request);
-
-    server.post(
-        "/api/v1/event",
-        middleware! { |req|
-            postevent(req)
-        },
-    );
-    server.get(
-        "/api/v1/event",
-        middleware! { |req|
-            getevent(req)
-        },
-    );
-
-    server.post(
-        "/api/v1/measure",
-        middleware! { |req|
-            postmeasure(req)
-        },
-    );
-
-    server.get(
-        "/api/v1/measure",
-        middleware! { |req|
-            getmeasure(req)
-        },
-    );
-
-    tracing::info!("server starting on port {}", server_options.port);
-
-    server
-        .listen(format!("0.0.0.0:{}", server_options.port))
-        .expect("could not start server");
+    let addr: std::net::SocketAddr = ([0, 0, 0, 0], server_options.port).into();
+    let listener = tokio::net::TcpListener::bind(addr).await.expect("bind");
+    tracing::info!(%addr, "listening");
+    axum::serve(listener, app).await.expect("serve");
 }
 
 fn launch_query(qo: &QueryOptions) {
@@ -570,8 +354,7 @@ fn launch_writer(filename: String, apikey: String) {
         }
     };
 
-    let gatekeeper = ApiKeys {};
-    let tid: i32 = match gatekeeper.check_keys(&apikey) {
+    let tid: i32 = match lookup_tenant_by_key(&apikey) {
         Some(i) => i,
         None => {
             tracing::info!("api key failure {}", &apikey);
@@ -732,7 +515,8 @@ fn clapparser() -> (Command, u8) {
     (cmd, cli.v)
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let (cmd, verbosity) = clapparser();
 
     let level = match verbosity {
@@ -749,9 +533,7 @@ fn main() {
         .init();
 
     match cmd {
-        Command::Server(server_options, servertype) => match servertype {
-            ServerType::Http => launch_server(&server_options),
-        },
+        Command::Server(server_options, _st) => launch_server(&server_options).await,
         Command::PipeReader(clioptions) => launch_writer(clioptions.filename, clioptions.apikey),
         Command::Querier(qo) => launch_query(&qo),
     }


### PR DESCRIPTION
## Summary

- Removes Nickel 0.11; adds Axum 0.7 + Tokio runtime + `tower-http`
- Auth middleware rewritten as `axum::middleware::from_fn`; tenant ID flows via request `Extension<TenantId>` newtype instead of a mutated raw header
- `TraceLayer::new_for_http()` replaces the hand-rolled `log_request` middleware
- `generic_post` deleted — `Json<T>` extractor handles deserialization
- All four API handlers converted to `async fn`; sync `postgres` calls bridged with `spawn_blocking` (temporary — removed in Stage 3)
- `launch_server` is async; `main` gets `#[tokio::main]`
- `launch_writer` / `launch_query` stay synchronous (separate CLI subcommands, not concurrent with the server)

## Stacked on

#14 (log→tracing)

## Test plan

- [ ] `cargo build --release` clean
- [ ] `cargo clippy --all-targets -- -D warnings` zero warnings (note: `typemap` future-incompat warning from Nickel is now gone)
- [ ] `cargo test` passes
- [ ] `curl localhost:1337/healthz` → 200, no auth required
- [ ] `curl localhost:1337/api/v1/event` with no key → 403
- [ ] `curl -H "X-PMETRICS-API-KEY: ..." localhost:1337/api/v1/event` → 200 JSON
- [ ] `./curltest.sh` all assertions pass