### PR TITLE
refactor: async Postgres via tokio-postgres + deadpool pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,6 +319,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-postgres"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d697d376cbfa018c23eb4caab1fd1883dd9c906a8c034e8d9a3cb06a7e0bef9"
+dependencies = [
+ "async-trait",
+ "deadpool",
+ "getrandom 0.2.17",
+ "tokio",
+ "tokio-postgres",
+ "tracing",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +476,19 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
@@ -462,6 +510,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hmac"
@@ -739,6 +793,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,32 +895,19 @@ dependencies = [
  "axum",
  "chrono",
  "clap",
+ "deadpool-postgres",
  "either",
  "itertools",
  "percent-encoding-rfc3986",
- "postgres",
  "serde",
  "serde_json",
  "time",
  "tokio",
+ "tokio-postgres",
  "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "postgres"
-version = "0.19.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "363e6dfbdd780d3aa3597b6eb430db76bb315fa9bad7fae595bb8def808b8470"
-dependencies = [
- "bytes",
- "fallible-iterator",
- "futures-util",
- "log",
- "tokio",
- "tokio-postgres",
 ]
 
 [[package]]
@@ -956,7 +1007,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,11 @@ tower = "0.5"
 tower-http = { version = "0.5", features = ["trace"] }
 percent-encoding-rfc3986 = "0.1"
 serde = { version = "1.0", features = ["derive"] }
-postgres = { version = "0.19.10", features = [
+tokio-postgres = { version = "0.7", features = [
     "with-serde_json-1",
     "with-chrono-0_4",
 ] }
+deadpool-postgres = { version = "0.14", features = ["rt_tokio_1"] }
 time = "0.3"
 chrono = { version = "0.4", features = ["serde"] }
 serde_json = "1.0"

--- a/src/bin/pmetrics.rs
+++ b/src/bin/pmetrics.rs
@@ -2,7 +2,7 @@
 pmetrics entry point
  **/
 use axum::{
-    extract::Extension,
+    extract::{Extension, State},
     http::StatusCode,
     middleware::{self, Next},
     response::Response,
@@ -13,7 +13,6 @@ use clap::{Parser, Subcommand};
 use std::fs::File;
 use std::io;
 use std::io::Read;
-use std::{thread, time};
 use tower_http::trace::TraceLayer;
 
 use chrono::prelude::{DateTime, Utc};
@@ -65,6 +64,11 @@ struct Event {
 #[derive(Clone, Copy)]
 struct TenantId(i32);
 
+#[derive(Clone)]
+struct AppState {
+    pool: deadpool_postgres::Pool,
+}
+
 // TODO: Api should have an accept: application/json request type, along with appropriate error codes.
 // Said error codes will be:
 //
@@ -81,119 +85,140 @@ struct TenantId(i32);
 
 // TODO: Write a Search api.
 
-fn writemeasure(
-    conn: &mut postgres::Client,
+async fn writemeasure(
+    client: &deadpool_postgres::Client,
     tid: i32,
     l: &MeasureIngest,
-) -> Result<u64, postgres::Error> {
-    conn.execute("INSERT INTO monitoring.measure (name, tenant_id, measurement, dict) VALUES ($1, $2, $3, $4)",
-                 &[&l.name, &tid, &l.measurement, &l.dict])
+) -> Result<u64, tokio_postgres::Error> {
+    client
+        .execute(
+            "INSERT INTO monitoring.measure (name, tenant_id, measurement, dict) \
+             VALUES ($1, $2, $3, $4)",
+            &[&l.name, &tid, &l.measurement, &l.dict],
+        )
+        .await
 }
 
 async fn post_measure(
+    State(state): State<AppState>,
     Extension(TenantId(tid)): Extension<TenantId>,
     Json(body): Json<MeasureIngest>,
 ) -> Result<StatusCode, (StatusCode, &'static str)> {
-    tokio::task::spawn_blocking(move || {
-        let mut conn = db::connect_to_db();
-        writemeasure(&mut conn, tid, &body)
-    })
-    .await
-    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "join error"))?
-    .map(|_| StatusCode::OK)
-    .map_err(|e| {
-        tracing::error!(?e, "db insert measure");
-        (StatusCode::BAD_GATEWAY, "server error")
-    })
+    let client = state
+        .pool
+        .get()
+        .await
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "pool"))?;
+    writemeasure(&client, tid, &body)
+        .await
+        .map(|_| StatusCode::OK)
+        .map_err(|e| {
+            tracing::error!(?e, "db insert measure");
+            (StatusCode::BAD_GATEWAY, "server error")
+        })
 }
 
 async fn get_measure(
+    State(state): State<AppState>,
     Extension(TenantId(tid)): Extension<TenantId>,
 ) -> Result<Json<Vec<Measure>>, (StatusCode, &'static str)> {
-    tokio::task::spawn_blocking(move || -> Result<Vec<Measure>, postgres::Error> {
-        let mut conn = db::connect_to_db();
-        let rows = conn.query(
+    let client = state
+        .pool
+        .get()
+        .await
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "pool"))?;
+    client
+        .query(
             "SELECT insertion_time, name, measurement, dict from monitoring.measure \
              where tenant_id = $1 order by insertion_time desc limit 100",
             &[&tid],
-        )?;
-        Ok(rows
-            .iter()
-            .map(|row| Measure {
-                insertion_time: row.get(0),
-                d: MeasureIngest {
-                    name: row.get(1),
-                    measurement: row.get(2),
-                    dict: row.get(3),
-                },
-            })
-            .collect())
-    })
-    .await
-    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "join error"))?
-    .map(Json)
-    .map_err(|e| {
-        tracing::error!(?e, "db query measures");
-        (StatusCode::INTERNAL_SERVER_ERROR, "server error")
-    })
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!(?e, "db query measures");
+            (StatusCode::INTERNAL_SERVER_ERROR, "server error")
+        })
+        .map(|rows| {
+            Json(
+                rows.iter()
+                    .map(|row| Measure {
+                        insertion_time: row.get(0),
+                        d: MeasureIngest {
+                            name: row.get(1),
+                            measurement: row.get(2),
+                            dict: row.get(3),
+                        },
+                    })
+                    .collect(),
+            )
+        })
 }
 
-fn writeevent(
-    conn: &mut postgres::Client,
+async fn writeevent(
+    client: &deadpool_postgres::Client,
     tid: i32,
     l: &EventIngest,
-) -> Result<u64, postgres::Error> {
-    conn.execute(
-        "INSERT INTO monitoring.event (name, tenant_id, dict) VALUES ($1, $2, $3)",
-        &[&l.name, &tid, &l.dict],
-    )
+) -> Result<u64, tokio_postgres::Error> {
+    client
+        .execute(
+            "INSERT INTO monitoring.event (name, tenant_id, dict) VALUES ($1, $2, $3)",
+            &[&l.name, &tid, &l.dict],
+        )
+        .await
 }
 
 async fn post_event(
+    State(state): State<AppState>,
     Extension(TenantId(tid)): Extension<TenantId>,
     Json(body): Json<EventIngest>,
 ) -> Result<StatusCode, (StatusCode, &'static str)> {
-    tokio::task::spawn_blocking(move || {
-        let mut conn = db::connect_to_db();
-        writeevent(&mut conn, tid, &body)
-    })
-    .await
-    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "join error"))?
-    .map(|_| StatusCode::OK)
-    .map_err(|e| {
-        tracing::error!(?e, "db insert event");
-        (StatusCode::BAD_GATEWAY, "server error")
-    })
+    let client = state
+        .pool
+        .get()
+        .await
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "pool"))?;
+    writeevent(&client, tid, &body)
+        .await
+        .map(|_| StatusCode::OK)
+        .map_err(|e| {
+            tracing::error!(?e, "db insert event");
+            (StatusCode::BAD_GATEWAY, "server error")
+        })
 }
 
 async fn get_event(
+    State(state): State<AppState>,
     Extension(TenantId(tid)): Extension<TenantId>,
 ) -> Result<Json<Vec<Event>>, (StatusCode, &'static str)> {
-    tokio::task::spawn_blocking(move || -> Result<Vec<Event>, postgres::Error> {
-        let mut conn = db::connect_to_db();
-        let rows = conn.query(
+    let client = state
+        .pool
+        .get()
+        .await
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "pool"))?;
+    client
+        .query(
             "SELECT insertion_time, name, dict from monitoring.event \
              where tenant_id = $1 order by insertion_time desc limit 100",
             &[&tid],
-        )?;
-        Ok(rows
-            .iter()
-            .map(|row| Event {
-                insertion_time: row.get(0),
-                d: EventIngest {
-                    name: row.get(1),
-                    dict: row.get(2),
-                },
-            })
-            .collect())
-    })
-    .await
-    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "join error"))?
-    .map(Json)
-    .map_err(|e| {
-        tracing::error!(?e, "db query events");
-        (StatusCode::INTERNAL_SERVER_ERROR, "server error")
-    })
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!(?e, "db query events");
+            (StatusCode::INTERNAL_SERVER_ERROR, "server error")
+        })
+        .map(|rows| {
+            Json(
+                rows.iter()
+                    .map(|row| Event {
+                        insertion_time: row.get(0),
+                        d: EventIngest {
+                            name: row.get(1),
+                            dict: row.get(2),
+                        },
+                    })
+                    .collect(),
+            )
+        })
 }
 
 async fn root() -> &'static str {
@@ -208,19 +233,8 @@ async fn healthz() -> &'static str {
 //////////////////////////////
 // API KEY / tenant middleware.
 
-fn lookup_tenant_by_key(k: &str) -> Option<i32> {
-    let mut conn = db::connect_to_db();
-    let query = "SELECT uid from monitoring.tenant where apikey = $1";
-    match conn.query(query, &[&k.to_string()]) {
-        Ok(rows) => rows.first().map(|row| row.get(0)),
-        Err(e) => {
-            tracing::error!("error=true module=db error={e:?} query={query}");
-            None
-        }
-    }
-}
-
 async fn check_api_keys(
+    State(state): State<AppState>,
     mut req: axum::extract::Request,
     next: Next,
 ) -> Result<Response, StatusCode> {
@@ -231,11 +245,25 @@ async fn check_api_keys(
         .ok_or(StatusCode::FORBIDDEN)?
         .to_string();
 
-    let tid = tokio::task::spawn_blocking(move || lookup_tenant_by_key(&key))
+    let client = state
+        .pool
+        .get()
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let row = client
+        .query_opt(
+            "SELECT uid FROM monitoring.tenant WHERE apikey = $1",
+            &[&key],
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!(?e, "db auth lookup");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
         .ok_or(StatusCode::FORBIDDEN)?;
 
+    let tid: i32 = row.get(0);
     req.extensions_mut().insert(TenantId(tid));
     Ok(next.run(req).await)
 }
@@ -243,16 +271,21 @@ async fn check_api_keys(
 async fn launch_server(server_options: &ServerOptions) {
     tracing::info!("server initializing");
 
+    let state = AppState {
+        pool: db::build_pool(),
+    };
+
     let api = Router::new()
         .route("/event", post(post_event).get(get_event))
         .route("/measure", post(post_measure).get(get_measure))
-        .layer(middleware::from_fn(check_api_keys));
+        .layer(middleware::from_fn_with_state(state.clone(), check_api_keys));
 
     let app = Router::new()
         .route("/", get(root))
         .route("/healthz", get(healthz))
         .nest("/api/v1", api)
-        .layer(TraceLayer::new_for_http());
+        .layer(TraceLayer::new_for_http())
+        .with_state(state);
 
     let addr: std::net::SocketAddr = ([0, 0, 0, 0], server_options.port).into();
     let listener = tokio::net::TcpListener::bind(addr).await.expect("bind");
@@ -260,68 +293,63 @@ async fn launch_server(server_options: &ServerOptions) {
     axum::serve(listener, app).await.expect("serve");
 }
 
-fn launch_query(qo: &QueryOptions) {
-    let mut conn = db::connect_to_db();
+async fn launch_query(qo: &QueryOptions) {
+    let pool = db::build_pool();
+    let client = pool.get().await.expect("pool get for query");
     println!("{qo:?}");
-    // pg / rust-postgres demand i64 as the type to be passed in.
     let last: i64 = qo.last.into();
     let printable = match qo.metric_type {
         MetricTypeOption::E => {
-            let mut vec: Vec<IntrusiveEvent> = Vec::new();
-            let query = "SELECT insertion_time, name, dict from monitoring.event
-order by insertion_time desc
-limit $1";
-            let result = match conn.query(query, &[&last]) {
+            let query = "SELECT insertion_time, name, dict from monitoring.event \
+                         order by insertion_time desc limit $1";
+            match client.query(query, &[&last]).await {
                 Ok(rows) => {
-                    for row in &rows {
-                        vec.push(IntrusiveEvent {
+                    let vec: Vec<IntrusiveEvent> = rows
+                        .iter()
+                        .map(|row| IntrusiveEvent {
                             insertion_time: row.get(0),
                             name: row.get(1),
                             dict: row.get(2),
-                        });
+                        })
+                        .collect();
+                    match serde_json::to_string_pretty(&vec) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            tracing::error!("error=true module=web error={e:?} class=json-render");
+                            return;
+                        }
                     }
-                    serde_json::to_string_pretty(&vec)
                 }
                 Err(e) => {
                     tracing::error!("error=true module=db error={e:?} query={query}");
-                    return;
-                }
-            };
-            match result {
-                Ok(s) => s,
-                Err(e) => {
-                    tracing::error!("error=true module=web error={e:?} class=json-render");
                     return;
                 }
             }
         }
         MetricTypeOption::M => {
-            let mut vec: Vec<IntrusiveMeasure> = Vec::new();
-            let query = "SELECT insertion_time, name, measurement, dict
-from monitoring.measure
-order by insertion_time desc
-limit $1";
-            let result = match conn.query(query, &[&last]) {
+            let query = "SELECT insertion_time, name, measurement, dict \
+                         from monitoring.measure order by insertion_time desc limit $1";
+            match client.query(query, &[&last]).await {
                 Ok(rows) => {
-                    for row in &rows {
-                        vec.push(IntrusiveMeasure {
+                    let vec: Vec<IntrusiveMeasure> = rows
+                        .iter()
+                        .map(|row| IntrusiveMeasure {
                             insertion_time: row.get(0),
                             name: row.get(1),
                             measurement: row.get(2),
                             dict: row.get(3),
-                        });
+                        })
+                        .collect();
+                    match serde_json::to_string_pretty(&vec) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            tracing::error!("error=true module=web error={e:?} class=json-render");
+                            return;
+                        }
                     }
-                    serde_json::to_string_pretty(&vec)
                 }
                 Err(e) => {
                     tracing::error!("error=true module=db error={e:?} query={query}");
-                    return;
-                }
-            };
-            match result {
-                Ok(s) => s,
-                Err(e) => {
-                    tracing::error!("error=true module=web error={e:?} class=json-render");
                     return;
                 }
             }
@@ -337,8 +365,9 @@ enum PipeReader {
     E(EventIngest),
 }
 
-fn launch_writer(filename: String, apikey: String) {
-    let mut conn = db::connect_to_db();
+async fn launch_writer(filename: String, apikey: String) {
+    let pool = db::build_pool();
+    let client = pool.get().await.expect("pool get for writer");
 
     let mut file: Box<dyn Read> = match filename.as_str() {
         "-" => Box::new(io::stdin()),
@@ -354,13 +383,18 @@ fn launch_writer(filename: String, apikey: String) {
         }
     };
 
-    let tid: i32 = match lookup_tenant_by_key(&apikey) {
-        Some(i) => i,
-        None => {
+    let tid: i32 = client
+        .query_opt(
+            "SELECT uid FROM monitoring.tenant WHERE apikey = $1",
+            &[&apikey],
+        )
+        .await
+        .expect("api key lookup")
+        .map(|row| row.get(0))
+        .unwrap_or_else(|| {
             tracing::info!("api key failure {}", &apikey);
             panic!("api key didn't work");
-        }
-    };
+        });
 
     loop {
         let mut buffer = String::new();
@@ -381,12 +415,12 @@ fn launch_writer(filename: String, apikey: String) {
                             for row in &dataz {
                                 match row {
                                     PipeReader::M(measure) => {
-                                        if let Err(e) = writemeasure(&mut conn, tid, measure) {
+                                        if let Err(e) = writemeasure(&client, tid, measure).await {
                                             tracing::error!("error=true module=db error={e:?} class=measure-write");
                                         }
                                     }
                                     PipeReader::E(event) => {
-                                        if let Err(e) = writeevent(&mut conn, tid, event) {
+                                        if let Err(e) = writeevent(&client, tid, event).await {
                                             tracing::error!("error=true module=db error={e:?} class=event-write");
                                         }
                                     }
@@ -405,9 +439,7 @@ fn launch_writer(filename: String, apikey: String) {
             }
         }
 
-        // One second pulled out of thin air.
-        let one = time::Duration::from_secs(1);
-        thread::sleep(one);
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
     }
 }
 
@@ -534,7 +566,9 @@ async fn main() {
 
     match cmd {
         Command::Server(server_options, _st) => launch_server(&server_options).await,
-        Command::PipeReader(clioptions) => launch_writer(clioptions.filename, clioptions.apikey),
-        Command::Querier(qo) => launch_query(&qo),
+        Command::PipeReader(clioptions) => {
+            launch_writer(clioptions.filename, clioptions.apikey).await
+        }
+        Command::Querier(qo) => launch_query(&qo).await,
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,9 +1,8 @@
-extern crate postgres;
+use deadpool_postgres::{Config, Pool, Runtime};
 use percent_encoding_rfc3986::{utf8_percent_encode, NON_ALPHANUMERIC};
-use postgres::{Client, NoTls};
 use std::collections::HashMap;
 use std::env;
-
+use tokio_postgres::NoTls;
 
 trait PgConn {
     fn from_env() -> Self
@@ -101,8 +100,6 @@ impl PgConn for PostgresClientArgs {
             None => "localhost",
         };
 
-        eprintln!("{pguser} {pghost} {pgport} {pgdb}");
-
         PostgresClientArgs {
             user: pguser.to_string(),
             password: pgpass.to_string(),
@@ -123,7 +120,6 @@ impl PgConn for PostgresClientArgs {
     }
 }
 
-// hacky facade for different env var combos.
 fn get_connection_string() -> String {
     let envmap: HashMap<String, String> = env::vars().collect();
     if envmap.contains_key("INSTANCE_UNIX_SOCKET") {
@@ -133,12 +129,10 @@ fn get_connection_string() -> String {
     }
 }
 
-pub fn connect_to_db() -> postgres::Client {
-    let cs = get_connection_string();
-
-    let conn = Client::connect(cs.as_str(), NoTls).expect("could not connect to database");
-
-    tracing::info!("started pg conn");
-
-    conn
+pub fn build_pool() -> Pool {
+    let mut cfg = Config::new();
+    cfg.url = Some(get_connection_string());
+    cfg.pool = Some(deadpool_postgres::PoolConfig::new(16));
+    cfg.create_pool(Some(Runtime::Tokio1), NoTls)
+        .expect("create pg pool")
 }


### PR DESCRIPTION
## Summary

- Removes synchronous `postgres` 0.19; adds `tokio-postgres` 0.7 + `deadpool-postgres` 0.14 (pool max 16)
- `db.rs`: `connect_to_db` replaced by `build_pool() -> Pool`; connection string helpers (TCP + Unix socket) unchanged
- `AppState { pool }` introduced and wired via `Router::with_state`; auth middleware updated to `from_fn_with_state`
- All four API handlers now take `State<AppState>`, `pool.get().await` directly — no `spawn_blocking`
- `writemeasure` / `writeevent` made `async`, taking `&deadpool_postgres::Client`
- `launch_query` and `launch_writer` are now `async`; `thread::sleep` replaced with `tokio::time::sleep`
- Closes #3

## Stacked on

#15 (Nickel→Axum) → #14 (log→tracing)

## Test plan

- [ ] `cargo build --release` clean
- [ ] `cargo clippy --all-targets -- -D warnings` zero warnings
- [ ] `cargo test` passes
- [ ] `./curltest.sh` all assertions pass
- [ ] Under concurrent load (`ab -n 2000 -c 64 ...`): no failures; `pg_stat_activity` connection count stays ≤ 16
- [ ] Pipe reader: `echo '[{"M":{"name":"cpu","measurement":0.42,"dict":{}}}]' | ./target/release/pmetrics pipe --file - --api-key <key>` row lands in DB
- [ ] Querier: `./target/release/pmetrics querier e 5` returns JSON