### PR TITLE
feat: Add POST /api/v1/ingest bulk endpoint

### DIFF
--- a/src/bin/pmetrics.rs
+++ b/src/bin/pmetrics.rs
@@ -374,23 +374,47 @@ async fn post_ingest(
     Extension(TenantId(tid)): Extension<TenantId>,
     Json(items): Json<Vec<PipeReader>>,
 ) -> Result<StatusCode, (StatusCode, &'static str)> {
-    let client = state
+    if items.is_empty() {
+        return Ok(StatusCode::OK);
+    }
+    let mut client = state
         .pool
         .get()
         .await
         .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "pool"))?;
-    for item in &items {
+    let txn = client.transaction().await.map_err(|e| {
+        tracing::error!(?e, "db begin transaction");
+        (StatusCode::BAD_GATEWAY, "server error")
+    })?;
+    for (idx, item) in items.iter().enumerate() {
         match item {
-            PipeReader::M(m) => writemeasure(&client, tid, m).await.map_err(|e| {
-                tracing::error!(?e, "bulk insert measure");
-                (StatusCode::BAD_GATEWAY, "db error")
-            })?,
-            PipeReader::E(e) => writeevent(&client, tid, e).await.map_err(|e| {
-                tracing::error!(?e, "bulk insert event");
-                (StatusCode::BAD_GATEWAY, "db error")
-            })?,
+            PipeReader::M(m) => txn
+                .execute(
+                    "INSERT INTO monitoring.measure (name, tenant_id, measurement, dict) \
+                     VALUES ($1, $2, $3, $4)",
+                    &[&m.name, &tid, &m.measurement, &m.dict],
+                )
+                .await
+                .map_err(|e| {
+                    tracing::error!(?e, idx, "bulk insert measure");
+                    (StatusCode::BAD_GATEWAY, "db error")
+                })?,
+            PipeReader::E(ev) => txn
+                .execute(
+                    "INSERT INTO monitoring.event (name, tenant_id, dict) VALUES ($1, $2, $3)",
+                    &[&ev.name, &tid, &ev.dict],
+                )
+                .await
+                .map_err(|e| {
+                    tracing::error!(?e, idx, "bulk insert event");
+                    (StatusCode::BAD_GATEWAY, "db error")
+                })?,
         };
     }
+    txn.commit().await.map_err(|e| {
+        tracing::error!(?e, "db commit transaction");
+        (StatusCode::BAD_GATEWAY, "server error")
+    })?;
     Ok(StatusCode::OK)
 }
 

--- a/src/bin/pmetrics.rs
+++ b/src/bin/pmetrics.rs
@@ -17,8 +17,8 @@ use tower_http::trace::TraceLayer;
 
 use chrono::prelude::{DateTime, Utc};
 
-use serde::{Deserialize, Serialize};
 use pmetrics::db;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -278,7 +278,11 @@ async fn launch_server(server_options: &ServerOptions) {
     let api = Router::new()
         .route("/event", post(post_event).get(get_event))
         .route("/measure", post(post_measure).get(get_measure))
-        .layer(middleware::from_fn_with_state(state.clone(), check_api_keys));
+        .route("/ingest", post(post_ingest))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            check_api_keys,
+        ));
 
     let app = Router::new()
         .route("/", get(root))
@@ -363,6 +367,31 @@ async fn launch_query(qo: &QueryOptions) {
 enum PipeReader {
     M(MeasureIngest),
     E(EventIngest),
+}
+
+async fn post_ingest(
+    State(state): State<AppState>,
+    Extension(TenantId(tid)): Extension<TenantId>,
+    Json(items): Json<Vec<PipeReader>>,
+) -> Result<StatusCode, (StatusCode, &'static str)> {
+    let client = state
+        .pool
+        .get()
+        .await
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "pool"))?;
+    for item in &items {
+        match item {
+            PipeReader::M(m) => writemeasure(&client, tid, m).await.map_err(|e| {
+                tracing::error!(?e, "bulk insert measure");
+                (StatusCode::BAD_GATEWAY, "db error")
+            })?,
+            PipeReader::E(e) => writeevent(&client, tid, e).await.map_err(|e| {
+                tracing::error!(?e, "bulk insert event");
+                (StatusCode::BAD_GATEWAY, "db error")
+            })?,
+        };
+    }
+    Ok(StatusCode::OK)
 }
 
 async fn launch_writer(filename: String, apikey: String) {

--- a/src/db.rs
+++ b/src/db.rs
@@ -89,7 +89,9 @@ impl PgConn for PostgresClientArgs {
             Some(s) => match s.parse::<u16>() {
                 Ok(p) => p,
                 Err(err) => {
-                    tracing::info!("error=true module=db class=env-parse-int value={s} error={err:?}");
+                    tracing::info!(
+                        "error=true module=db class=env-parse-int value={s} error={err:?}"
+                    );
                     5432
                 }
             },


### PR DESCRIPTION
## Summary
- Adds `POST /api/v1/ingest` handler under the existing auth layer
- Accepts `Vec<PipeReader>` — same JSON format as the pipe-reader CLI: `[{"M": {...}}, {"E": {...}}]`
- Reuses `writemeasure` and `writeevent` helpers; returns 502 on first DB failure, 200 on success
- No new types needed — reuses the existing `PipeReader`, `MeasureIngest`, and `EventIngest` structs

## Test plan
- [ ] `cargo build` clean
- [ ] `cargo clippy -- -D warnings` clean
- [ ] Manual: `curl -H "X-PMETRICS-API-KEY: a-wiWimWyilf" -H "content-type: application/json" -d '[{"M":{"name":"cpu","measurement":0.42,"dict":{}}}]' -X POST localhost:1337/api/v1/ingest` → 200
- [ ] Empty array returns 200
- [ ] Missing auth returns 403