### PR TITLE
feat: Multiple API keys per tenant with scoped permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,8 +64,10 @@ jobs:
         export PGDATABASE=postgres
         export PGPORT=5432
         psql -1 -f schema/monitoring.log.ddl
-        psql -1 -c "INSERT INTO monitoring.tenant(tenantname, apikey) values ('test',  'a-wiWimWyilf')"
-        psql -1 -c "INSERT INTO monitoring.tenant(tenantname, apikey) values ('test',  'a-IbpyucIo')"
+        psql -1 -f schema/002_multi_api_keys.sql
+        psql -1 -c "INSERT INTO monitoring.tenant(tenantname) values ('test')"
+        psql -1 -c "INSERT INTO monitoring.api_key(tenant_id, key, label, permissions) SELECT uid, 'a-wiWimWyilf', 'test-key-1', '{tenant_read,tenant_write,make_api_key,disable_api_key}' FROM monitoring.tenant WHERE tenantname='test' LIMIT 1"
+        psql -1 -c "INSERT INTO monitoring.api_key(tenant_id, key, label, permissions) SELECT uid, 'a-IbpyucIo', 'test-key-2', '{tenant_read,tenant_write}' FROM monitoring.tenant WHERE tenantname='test' LIMIT 1"
     
     - name: Run tests
       uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,6 +899,7 @@ dependencies = [
  "either",
  "itertools",
  "percent-encoding-rfc3986",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "time",
@@ -923,7 +924,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand",
+ "rand 0.9.2",
  "sha2",
  "stringprep",
 ]
@@ -983,12 +984,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -998,7 +1020,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1332,7 +1363,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand",
+ "rand 0.9.2",
  "socket2 0.5.10",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,4 @@ chrono = { version = "0.4", features = ["serde"] }
 serde_json = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
-rand = { version = "0.8", features = ["small_rng"] }
+rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ chrono = { version = "0.4", features = ["serde"] }
 serde_json = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+rand = { version = "0.8", features = ["small_rng"] }

--- a/schema/002_multi_api_keys.sql
+++ b/schema/002_multi_api_keys.sql
@@ -1,0 +1,20 @@
+CREATE TABLE monitoring.api_key (
+    id          serial primary key,
+    tenant_id   int not null references monitoring.tenant(uid) on delete cascade,
+    key         text not null unique,
+    label       text not null default '',
+    permissions text[] not null default '{tenant_read,tenant_write}',
+    created_at  timestamptz not null default now(),
+    revoked_at  timestamptz,
+    constraint revoked_after_created check (revoked_at is null or revoked_at >= created_at)
+);
+
+CREATE INDEX idx_api_key_active ON monitoring.api_key(key) WHERE revoked_at IS NULL;
+
+-- Migrate existing single keys, granting full permissions
+INSERT INTO monitoring.api_key (tenant_id, key, label, permissions)
+SELECT uid, apikey, tenantname, '{tenant_read,tenant_write,make_api_key,disable_api_key}'
+FROM monitoring.tenant;
+
+ALTER TABLE monitoring.tenant DROP COLUMN apikey;
+DROP INDEX IF EXISTS only_one_no_dupes;

--- a/schema/002_multi_api_keys.sql
+++ b/schema/002_multi_api_keys.sql
@@ -1,3 +1,5 @@
+BEGIN;
+
 CREATE TABLE monitoring.api_key (
     id          serial primary key,
     tenant_id   int not null references monitoring.tenant(uid) on delete cascade,
@@ -18,3 +20,5 @@ FROM monitoring.tenant;
 
 ALTER TABLE monitoring.tenant DROP COLUMN apikey;
 DROP INDEX IF EXISTS only_one_no_dupes;
+
+COMMIT;

--- a/src/bin/pmetrics.rs
+++ b/src/bin/pmetrics.rs
@@ -313,6 +313,13 @@ struct CreatedKey {
     key: String,
 }
 
+const VALID_PERMISSIONS: &[&str] = &[
+    "tenant_read",
+    "tenant_write",
+    "make_api_key",
+    "disable_api_key",
+];
+
 async fn create_key(
     State(state): State<AppState>,
     Extension(TenantId(tid)): Extension<TenantId>,
@@ -321,6 +328,11 @@ async fn create_key(
 ) -> Result<Json<CreatedKey>, (StatusCode, &'static str)> {
     if !perms.iter().any(|p| p == "make_api_key") {
         return Err((StatusCode::FORBIDDEN, "missing make_api_key permission"));
+    }
+    for p in &body.permissions {
+        if !VALID_PERMISSIONS.contains(&p.as_str()) {
+            return Err((StatusCode::UNPROCESSABLE_ENTITY, "unknown permission value"));
+        }
     }
     let new_key = format!(
         "a-{}",
@@ -538,18 +550,24 @@ async fn launch_writer(filename: String, apikey: String) {
         }
     };
 
-    let tid: i32 = client
+    let row = client
         .query_opt(
-            "SELECT tenant_id FROM monitoring.api_key WHERE key = $1 AND revoked_at IS NULL",
+            "SELECT tenant_id, permissions FROM monitoring.api_key \
+             WHERE key = $1 AND revoked_at IS NULL",
             &[&apikey],
         )
         .await
         .expect("api key lookup")
-        .map(|row| row.get(0))
         .unwrap_or_else(|| {
             tracing::info!("api key failure {}", &apikey);
             panic!("api key didn't work");
         });
+    let tid: i32 = row.get(0);
+    let perms: Vec<String> = row.get(1);
+    if !perms.iter().any(|p| p == "tenant_write") {
+        tracing::error!("api key {} lacks tenant_write permission", &apikey);
+        panic!("api key lacks tenant_write permission");
+    }
 
     loop {
         let mut buffer = String::new();

--- a/src/bin/pmetrics.rs
+++ b/src/bin/pmetrics.rs
@@ -2,14 +2,15 @@
 pmetrics entry point
  **/
 use axum::{
-    extract::{Extension, State},
+    extract::{Extension, Path, State},
     http::StatusCode,
     middleware::{self, Next},
     response::Response,
-    routing::{get, post},
+    routing::{delete, get, post},
     Json, Router,
 };
 use clap::{Parser, Subcommand};
+use rand::distributions::{Alphanumeric, DistString};
 use std::fs::File;
 use std::io;
 use std::io::Read;
@@ -17,8 +18,8 @@ use tower_http::trace::TraceLayer;
 
 use chrono::prelude::{DateTime, Utc};
 
-use serde::{Deserialize, Serialize};
 use pmetrics::db;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -65,8 +66,27 @@ struct Event {
 struct TenantId(i32);
 
 #[derive(Clone)]
+struct ApiPermissions(Vec<String>);
+
+#[derive(Clone)]
 struct AppState {
     pool: deadpool_postgres::Pool,
+}
+
+// API key management types
+#[derive(Debug, Deserialize)]
+struct CreateKeyRequest {
+    label: String,
+    permissions: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ApiKeyRecord {
+    id: i32,
+    label: String,
+    permissions: Vec<String>,
+    created_at: DateTime<Utc>,
+    revoked_at: Option<DateTime<Utc>>,
 }
 
 // TODO: Api should have an accept: application/json request type, along with appropriate error codes.
@@ -102,8 +122,12 @@ async fn writemeasure(
 async fn post_measure(
     State(state): State<AppState>,
     Extension(TenantId(tid)): Extension<TenantId>,
+    Extension(ApiPermissions(perms)): Extension<ApiPermissions>,
     Json(body): Json<MeasureIngest>,
 ) -> Result<StatusCode, (StatusCode, &'static str)> {
+    if !perms.iter().any(|p| p == "tenant_write") {
+        return Err((StatusCode::FORBIDDEN, "missing tenant_write permission"));
+    }
     let client = state
         .pool
         .get()
@@ -121,7 +145,11 @@ async fn post_measure(
 async fn get_measure(
     State(state): State<AppState>,
     Extension(TenantId(tid)): Extension<TenantId>,
+    Extension(ApiPermissions(perms)): Extension<ApiPermissions>,
 ) -> Result<Json<Vec<Measure>>, (StatusCode, &'static str)> {
+    if !perms.iter().any(|p| p == "tenant_read") {
+        return Err((StatusCode::FORBIDDEN, "missing tenant_read permission"));
+    }
     let client = state
         .pool
         .get()
@@ -170,8 +198,12 @@ async fn writeevent(
 async fn post_event(
     State(state): State<AppState>,
     Extension(TenantId(tid)): Extension<TenantId>,
+    Extension(ApiPermissions(perms)): Extension<ApiPermissions>,
     Json(body): Json<EventIngest>,
 ) -> Result<StatusCode, (StatusCode, &'static str)> {
+    if !perms.iter().any(|p| p == "tenant_write") {
+        return Err((StatusCode::FORBIDDEN, "missing tenant_write permission"));
+    }
     let client = state
         .pool
         .get()
@@ -189,7 +221,11 @@ async fn post_event(
 async fn get_event(
     State(state): State<AppState>,
     Extension(TenantId(tid)): Extension<TenantId>,
+    Extension(ApiPermissions(perms)): Extension<ApiPermissions>,
 ) -> Result<Json<Vec<Event>>, (StatusCode, &'static str)> {
+    if !perms.iter().any(|p| p == "tenant_read") {
+        return Err((StatusCode::FORBIDDEN, "missing tenant_read permission"));
+    }
     let client = state
         .pool
         .get()
@@ -231,6 +267,117 @@ async fn healthz() -> &'static str {
 }
 
 //////////////////////////////
+// Key management handlers
+
+async fn list_keys(
+    State(state): State<AppState>,
+    Extension(TenantId(tid)): Extension<TenantId>,
+    Extension(ApiPermissions(perms)): Extension<ApiPermissions>,
+) -> Result<Json<Vec<ApiKeyRecord>>, (StatusCode, &'static str)> {
+    if !perms.iter().any(|p| p == "make_api_key") {
+        return Err((StatusCode::FORBIDDEN, "missing make_api_key permission"));
+    }
+    let client = state
+        .pool
+        .get()
+        .await
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "pool"))?;
+    client
+        .query(
+            "SELECT id, label, permissions, created_at, revoked_at \
+             FROM monitoring.api_key WHERE tenant_id = $1 ORDER BY created_at DESC",
+            &[&tid],
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!(?e, "db list keys");
+            (StatusCode::INTERNAL_SERVER_ERROR, "server error")
+        })
+        .map(|rows| {
+            Json(
+                rows.iter()
+                    .map(|row| ApiKeyRecord {
+                        id: row.get(0),
+                        label: row.get(1),
+                        permissions: row.get(2),
+                        created_at: row.get(3),
+                        revoked_at: row.get(4),
+                    })
+                    .collect(),
+            )
+        })
+}
+
+#[derive(Serialize)]
+struct CreatedKey {
+    key: String,
+}
+
+async fn create_key(
+    State(state): State<AppState>,
+    Extension(TenantId(tid)): Extension<TenantId>,
+    Extension(ApiPermissions(perms)): Extension<ApiPermissions>,
+    Json(body): Json<CreateKeyRequest>,
+) -> Result<Json<CreatedKey>, (StatusCode, &'static str)> {
+    if !perms.iter().any(|p| p == "make_api_key") {
+        return Err((StatusCode::FORBIDDEN, "missing make_api_key permission"));
+    }
+    let new_key = format!(
+        "a-{}",
+        Alphanumeric.sample_string(&mut rand::thread_rng(), 16)
+    );
+    let client = state
+        .pool
+        .get()
+        .await
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "pool"))?;
+    client
+        .execute(
+            "INSERT INTO monitoring.api_key (tenant_id, key, label, permissions) \
+             VALUES ($1, $2, $3, $4)",
+            &[&tid, &new_key, &body.label, &body.permissions],
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!(?e, "db create key");
+            (StatusCode::BAD_GATEWAY, "server error")
+        })?;
+    Ok(Json(CreatedKey { key: new_key }))
+}
+
+async fn revoke_key(
+    State(state): State<AppState>,
+    Extension(TenantId(tid)): Extension<TenantId>,
+    Extension(ApiPermissions(perms)): Extension<ApiPermissions>,
+    Path(key_id): Path<i32>,
+) -> Result<StatusCode, (StatusCode, &'static str)> {
+    if !perms.iter().any(|p| p == "disable_api_key") {
+        return Err((StatusCode::FORBIDDEN, "missing disable_api_key permission"));
+    }
+    let client = state
+        .pool
+        .get()
+        .await
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "pool"))?;
+    let n = client
+        .execute(
+            "UPDATE monitoring.api_key SET revoked_at = now() \
+             WHERE id = $1 AND tenant_id = $2 AND revoked_at IS NULL",
+            &[&key_id, &tid],
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!(?e, "db revoke key");
+            (StatusCode::BAD_GATEWAY, "server error")
+        })?;
+    if n == 0 {
+        Err((StatusCode::NOT_FOUND, "key not found"))
+    } else {
+        Ok(StatusCode::OK)
+    }
+}
+
+//////////////////////////////
 // API KEY / tenant middleware.
 
 async fn check_api_keys(
@@ -253,7 +400,8 @@ async fn check_api_keys(
 
     let row = client
         .query_opt(
-            "SELECT uid FROM monitoring.tenant WHERE apikey = $1",
+            "SELECT tenant_id, permissions FROM monitoring.api_key \
+             WHERE key = $1 AND revoked_at IS NULL",
             &[&key],
         )
         .await
@@ -264,7 +412,9 @@ async fn check_api_keys(
         .ok_or(StatusCode::FORBIDDEN)?;
 
     let tid: i32 = row.get(0);
+    let perms: Vec<String> = row.get(1);
     req.extensions_mut().insert(TenantId(tid));
+    req.extensions_mut().insert(ApiPermissions(perms));
     Ok(next.run(req).await)
 }
 
@@ -278,7 +428,12 @@ async fn launch_server(server_options: &ServerOptions) {
     let api = Router::new()
         .route("/event", post(post_event).get(get_event))
         .route("/measure", post(post_measure).get(get_measure))
-        .layer(middleware::from_fn_with_state(state.clone(), check_api_keys));
+        .route("/keys", get(list_keys).post(create_key))
+        .route("/keys/:id", delete(revoke_key))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            check_api_keys,
+        ));
 
     let app = Router::new()
         .route("/", get(root))
@@ -385,7 +540,7 @@ async fn launch_writer(filename: String, apikey: String) {
 
     let tid: i32 = client
         .query_opt(
-            "SELECT uid FROM monitoring.tenant WHERE apikey = $1",
+            "SELECT tenant_id FROM monitoring.api_key WHERE key = $1 AND revoked_at IS NULL",
             &[&apikey],
         )
         .await

--- a/src/db.rs
+++ b/src/db.rs
@@ -89,7 +89,9 @@ impl PgConn for PostgresClientArgs {
             Some(s) => match s.parse::<u16>() {
                 Ok(p) => p,
                 Err(err) => {
-                    tracing::info!("error=true module=db class=env-parse-int value={s} error={err:?}");
+                    tracing::info!(
+                        "error=true module=db class=env-parse-int value={s} error={err:?}"
+                    );
                     5432
                 }
             },

--- a/start-db.sh
+++ b/start-db.sh
@@ -4,6 +4,8 @@ export PGUSER=postgres
 export PGDATABASE=postgres
 export PGPORT=5432
 psql -1 -f schema/monitoring.log.ddl
+psql -1 -f schema/002_multi_api_keys.sql
 
-psql -1 -c "INSERT INTO monitoring.tenant(tenantname, apikey) values ('test',  'a-wiWimWyilf')"
-psql -1 -c "INSERT INTO monitoring.tenant(tenantname, apikey) values ('test',  'a-IbpyucIo')"
+psql -1 -c "INSERT INTO monitoring.tenant(tenantname) values ('test')"
+psql -1 -c "INSERT INTO monitoring.api_key(tenant_id, key, label, permissions) SELECT uid, 'a-wiWimWyilf', 'test-key-1', '{tenant_read,tenant_write,make_api_key,disable_api_key}' FROM monitoring.tenant WHERE tenantname='test' LIMIT 1"
+psql -1 -c "INSERT INTO monitoring.api_key(tenant_id, key, label, permissions) SELECT uid, 'a-IbpyucIo', 'test-key-2', '{tenant_read,tenant_write}' FROM monitoring.tenant WHERE tenantname='test' LIMIT 1"


### PR DESCRIPTION
## Summary
- New `monitoring.api_key` table with `key`, `label`, `permissions text[]`, `created_at`, `revoked_at`; `revoked_at IS NULL` index for fast auth lookups
- Migration `schema/002_multi_api_keys.sql` migrates existing single tenant keys with full `{tenant_read,tenant_write,make_api_key,disable_api_key}` permissions, then drops the old `apikey` column from `monitoring.tenant`
- `check_api_keys` middleware updated to query `api_key` table and inject `ApiPermissions` alongside `TenantId`
- All data handlers (`post_event`, `get_event`, `post_measure`, `get_measure`) now check for `tenant_write`/`tenant_read` permission
- New key CRUD endpoints under `/api/v1/keys` (behind auth layer, require `make_api_key`/`disable_api_key`)
- `start-db.sh` and CI `test.yml` updated to run both schema files and seed via the new table

Closes #13, #4

## Test plan
- [ ] `start-db.sh` runs against fresh DB, seeds correctly
- [ ] `cargo build` clean
- [ ] `cargo clippy -- -D warnings` clean
- [ ] CI green
- [ ] `GET /api/v1/event` with old key `a-wiWimWyilf` returns 200 (migrated key still works)
- [ ] `POST /api/v1/keys` with key having `make_api_key` creates a new key
- [ ] New key works for data endpoints
- [ ] `DELETE /api/v1/keys/:id` revokes key; subsequent requests return 403
- [ ] Key with only `tenant_read` gets 403 on POST endpoints