### PR TITLE
feat: Add Makefile with coverage rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+PGPASSWORD ?= aargh
+PGHOST     ?= localhost
+PGUSER     ?= postgres
+PGDATABASE ?= postgres
+PGPORT     ?= 5432
+
+export PGPASSWORD PGHOST PGUSER PGDATABASE PGPORT
+
+.PHONY: coverage
+
+coverage:
+	cargo llvm-cov --all-features --workspace --summary-only

--- a/src/bin/pmetrics.rs
+++ b/src/bin/pmetrics.rs
@@ -946,7 +946,10 @@ mod tests {
     fn test_state() -> AppState {
         let recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
         let prometheus = recorder.handle();
-        AppState { pool: test_pool(), prometheus }
+        AppState {
+            pool: test_pool(),
+            prometheus,
+        }
     }
 
     async fn seed_tenant(client: &deadpool_postgres::Client) -> (i32, String) {
@@ -979,7 +982,10 @@ mod tests {
 
     async fn cleanup_tenant(client: &deadpool_postgres::Client, tid: i32) {
         client
-            .execute("DELETE FROM monitoring.api_key WHERE tenant_id = $1", &[&tid])
+            .execute(
+                "DELETE FROM monitoring.api_key WHERE tenant_id = $1",
+                &[&tid],
+            )
             .await
             .ok();
         client


### PR DESCRIPTION
## Summary

- Adds `Makefile` with a single `coverage` target
- `make coverage` runs `cargo llvm-cov --all-features --workspace --summary-only` and prints a coverage table
- PG env vars default to the dev setup; override on the command line: `PGHOST=myserver make coverage`

## Test plan

- [ ] `make coverage` runs cleanly and prints a summary line with overall % covered
- [ ] Override works: `PGHOST=localhost make coverage`